### PR TITLE
Fix SQL error from empty parent_id when moving root nodes

### DIFF
--- a/src/Baum/Move.php
+++ b/src/Baum/Move.php
@@ -276,6 +276,8 @@ class Move {
     if ( $this->position == 'child' )
       $this->_parentId = $this->target->getKey();
 
+	if(empty($this->_parentId)) $this->_parentId = 'NULL';
+	
     return $this->_parentId;
   }
 


### PR DESCRIPTION
Move::parentId() was returning empty when dealing with a root node. This resulted in an SQL error related to $parentSql of Move::updateStructure(). Not sure if hardcoding 'NULL' is the best way to do it but it seems to solve the problem.
