### PR TITLE
Add getNestedList() method

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -807,6 +807,26 @@ abstract class Node extends Model {
   }
 
   /**
+   * Return an key-value array indicating the node's depth with $seperator
+   *
+   * @return Array
+   */
+  public static function getNestedList($column, $key = null, $seperator = ' ') {
+    $instance = new static;
+
+    $key = $key ?: $instance->getKeyName();
+    $depthColumn = $instance->getDepthColumnName();
+
+    $nodes = $instance->newNestedSetQuery()->get()->toArray();
+
+    return array_combine(array_map(function($node) use($key) {
+      return $node[$key];
+    }, $nodes), array_map(function($node) use($seperator, $depthColumn, $column) {
+      return str_repeat($seperator, $node[$depthColumn]) . $node[$column];
+    }, $nodes));
+  }
+
+  /**
    * Return a new QueryBuilder (scope) object without the current node.
    *
    * @return \Illuminate\Database\Query\Builder

--- a/tests/BaumTest.php
+++ b/tests/BaumTest.php
@@ -120,6 +120,22 @@ class BaumTest extends PHPUnit_Framework_TestCase {
     $this->assertContains('Root 2', $leaves);
   }
 
+  public function testGetNestedList() {
+    $seperator = ' ';
+    $nestedList = Category::getNestedList('name', 'id', $seperator);
+
+    $expected = array(
+      1 => str_repeat($seperator, 0). 'Root 1',
+      2 => str_repeat($seperator, 1). 'Child 1',
+      3 => str_repeat($seperator, 1). 'Child 2',
+      4 => str_repeat($seperator, 2). 'Child 2.1',
+      5 => str_repeat($seperator, 1). 'Child 3',
+      6 => str_repeat($seperator, 0). 'Root 2',
+    );
+
+    $this->assertEquals($expected, $nestedList);
+  }
+
   public function testIsLeaf() {
     $this->assertTrue($this->categories('Child 1')->isLeaf());
     $this->assertTrue($this->categories('Child 2.1')->isLeaf());


### PR DESCRIPTION
Returns a key-value pair array indicating a node's depth with an optional seperator for filling selectboxes e.g.
