### PR TITLE
Prevent impossible moves to the left or right.

### DIFF
--- a/src/Baum/Move.php
+++ b/src/Baum/Move.php
@@ -205,11 +205,13 @@ class Move {
     if ( $this->node->equals($this->target) )
       throw new MoveNotPossibleException('A node cannot be moved to itself.');
 
-    if ( $this->position === 'left' && ($this->node->getLeft() - 1) === $this->node->parent->getLeft() )
-      throw new MoveNotPossibleException('This node cannot move any further to the left.');
+    if ( $this->node->parent ) {
+        if ( $this->position === 'left' && ($this->node->getLeft() - 1) === $this->node->parent->getLeft() )
+          throw new MoveNotPossibleException('This node cannot move any further to the left.');
 
-    if ( $this->position === 'right' && ($this->node->getRight() + 1) === $this->node->parent->getRight() )
-      throw new MoveNotPossibleException('This node cannot move any further to the right.');
+        if ( $this->position === 'right' && ($this->node->getRight() + 1) === $this->node->parent->getRight() )
+          throw new MoveNotPossibleException('This node cannot move any further to the right.');
+    }
 
     if ( $this->target->insideSubtree($this->node) )
       throw new MoveNotPossibleException('A node cannot be moved to a descendant of itself (inside moved tree).');


### PR DESCRIPTION
I've noticed an error occurs when performing a `moveLeft()` or `moveRight()` on a node that can't possibly move in that direction.

``` php
Fatal error: Call to a member function insideSubtree() on a non-object in /vendor/baum/baum/src/Baum/Move.php on line 208
```

Right now I'm using a custom check to prevent the error from occurring (see below), but I suspect a `MoveNotPossibleException` should be thrown (which in my case I could catch and discard, since I don't care if the move fails).

``` php
$category = Category::find($id);
$parent = $category->parent()->first();

switch ($direction) {
    case 'left':
        if (($category->getLeft() - 1) !== $parent->getLeft()) {
            $category->moveLeft();
        }
        break;

    case 'right':
        if (($category->getRight() + 1) !== $parent->getRight()) {
            $category->moveRight();
        }
        break;
}
```

I've made a few quick changes to the `Move` class that triggers the appropriate exceptions, however, I'm not familiar enough with the codebase, or nested sets, to know if this is the best possible solution.
