### PR TITLE
Don't constrain on scope when looking for roots

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -246,12 +246,13 @@ abstract class Node extends Model {
    * Get a new "scoped" query builder for the Node's model.
    *
    * @param  bool  $excludeDeleted
+   * @param  bool  $currentScope
    * @return \Illuminate\Database\Eloquent\Builder|static
    */
-  public function newNestedSetQuery($excludeDeleted = true) {
+  public function newNestedSetQuery($excludeDeleted = true, $currentScope = true) {
     $builder = $this->newQuery($excludeDeleted)->orderBy($this->getLeftColumnName());
 
-    if ( !empty($this->scoped) ) {
+    if ( $currentScope && !empty($this->scoped) ) {
       foreach($this->scoped as $scopeFld)
         $builder->where($scopeFld, '=', $this->$scopeFld);
     }
@@ -298,7 +299,7 @@ abstract class Node extends Model {
   public static function roots() {
     $instance = new static;
 
-    return $instance->newNestedSetQuery()->whereNull($instance->getParentColumnName());
+    return $instance->newNestedSetQuery(true, false)->whereNull($instance->getParentColumnName());
   }
 
   /**


### PR DESCRIPTION
When $scoped is set the Node::roots method was breaking since it was
attempting to find nodes with the same scope as $this (which was a
newly instantiated Node with no scope).

This patch introduces a new attribute to the newNestedSetQuery method
to constrain to the current scope, true by default. This is then set
to false when called from the roots method.
