### PR TITLE
fixed all sibling methods. there was a bug in base method siblingsAndSelf

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -465,7 +465,7 @@ abstract class Node extends Model {
    */
   public function siblingsAndSelf() {
     return $this->newNestedSetQuery()
-                ->where($this->getParentColumnName(), $this->getParentId());
+                ->where($this->getParentColumnName(), $this->id);
   }
 
   /**


### PR DESCRIPTION
While working with baum I noticed that the getSiblings() and all derivate functions seem to be buggy. I took a look into the database and everything was fine. Debugging took me into baum's code, seeing that the where statement in the base method siblingsAndSelf() is not correct. After fixing this up everything works great.
