### PR TITLE
- Changed toHierarchy() to order nodes based on their index in the collect...

### DIFF
--- a/src/Baum/Extensions/Eloquent/Collection.php
+++ b/src/Baum/Extensions/Eloquent/Collection.php
@@ -16,10 +16,10 @@ class Collection extends BaseCollection {
 
     if ( is_array($result) ) {
       while( list($n, $sub) = each($result) ) {
-        $new[$sub->getKey()] = $sub;
+        $new[$n] = $sub;
 
         if ( ! $sub->isLeaf() )
-          $new[$sub->getKey()]->setRelation('children', new BaseCollection($this->hierarchical($result)));
+          $new[$n]->setRelation('children', new BaseCollection($this->hierarchical($result)));
 
         $next_id = key($result);
 


### PR DESCRIPTION
- Changed toHierarchy() to order nodes based on their index in the collection rather than their ID

The current functionality uses the ID of the node which often leads to incorrect order. Changing toHierarchy to work off the index at least lets the order be based on the current order of the collection. In truth it would probably make more sense to have the order be based off the "left" field... However, this is my solution for now and IMO an improvement on what it was.
