### PR TITLE
$sortColumn to $orderColumn to match actual usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ If you wish to change this default behaviour you need to specify in your model
 the name of the column you wish to use to sort your results like this:
 
 ```php
-protected $sortColumn = 'name';
+protected $orderColumn = 'name';
 ```
 
 <a name="hierarchy-tree"></a>


### PR DESCRIPTION
Custom sorting column is implemented in `Node.php` as `$orderColumn`, not the `$sortColumn` shown in the documentation.
