### PR TITLE
have newNestedSetQuery use qualified order column

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -333,7 +333,7 @@ abstract class Node extends Model {
    * @return \Illuminate\Database\Eloquent\Builder|static
    */
   public function newNestedSetQuery($excludeDeleted = true) {
-    $builder = $this->newQuery($excludeDeleted)->orderBy($this->getOrderColumnName());
+    $builder = $this->newQuery($excludeDeleted)->orderBy($this->getQualifiedOrderColumnName());
 
     if ( $this->isScoped() ) {
       foreach($this->scoped as $scopeFld)


### PR DESCRIPTION
Joining a nested set query against another table with a column named the same as the order column (i.e. `name`) will cause an ambiguous column name SQL error. Using the qualified column name seems to address this.
