### PR TITLE
Fixes invalid tree following mass assignment update where nodes are dele...

### DIFF
--- a/src/Baum/SetMapper.php
+++ b/src/Baum/SetMapper.php
@@ -154,7 +154,9 @@ class SetMapper {
   }
 
   protected function deleteUnaffected($keys = array()) {
-    return $this->pruneScope()->whereNotIn($this->node->getKeyName(), $keys)->delete();
+    $nodes = $this->pruneScope()->whereNotIn($this->node->getKeyName(), $keys)->get();
+    foreach ($nodes as $node)
+      $node->delete();
   }
 
   protected function wrapInTransaction(Closure $callback) {


### PR DESCRIPTION
...ted

The previous code just did a SQL delete, i.e. a single call to the database to delete the "unaffected" records, i.e. the ones no longer in the tree. This fix fetches the nodes to be deleted using the same query as before, but calls the delete() method on each node individually, thus allowing Baum\Node's tree management events to kick in and update the lft and rght values for the ancestors of the deleted node, and handle children of the deleted node properly, rather than just orphaning them.
