### PR TITLE
Allow usage of table prefixes in "rebuild" command

### DIFF
--- a/src/Baum/SetValidator.php
+++ b/src/Baum/SetValidator.php
@@ -71,7 +71,7 @@ class SetValidator {
           $qualifiedRgtCol >= parent.$rgtCol)))";
 
     $query = $this->node->newQuery()
-      ->join($connection->raw($grammar->wrap($tableName).' AS parent'),
+      ->join($connection->raw($grammar->wrap( $grammar->getTablePrefix() . $tableName ).' AS parent'),
              $parentColumn, '=', $connection->raw('parent.'.$grammar->wrap($primaryKeyName)),
              'left outer')
       ->whereRaw($whereStm);


### PR DESCRIPTION
Added the table prefix to the validation command.
This function failed when a table prefix was set.
