### PR TITLE
Add the possibility to flush events for phpunit testing

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -109,7 +109,11 @@ abstract class Node extends Model {
    */
   protected static function boot() {
     parent::boot();
+    static::flushModelEvents();
+  }
 
+  public static function flushModelEvents()
+  {
     static::creating(function($node) {
       $node->setDefaultLeftAndRight();
     });


### PR DESCRIPTION
After spending some hours, I discovered that it is required to redefine model events after each single test with phpunit.

[Here](https://github.com/laravel/framework/issues/1181) is a description of the issue.

By putting the events definition to a separate function we allow writing tests for Node instances.
