### PR TITLE
We don't need to boot the service provider

### DIFF
--- a/src/Baum/BaumServiceProvider.php
+++ b/src/Baum/BaumServiceProvider.php
@@ -24,15 +24,6 @@ class BaumServiceProvider extends ServiceProvider {
   protected $defer = false;
 
   /**
-   * Bootstrap the application events.
-   *
-   * @return void
-   */
-  public function boot() {
-    $this->package('baum/baum');
-  }
-
-  /**
    * Register the service provider.
    *
    * @return void


### PR DESCRIPTION
This doesn't work on laravel 5, and we don't need to do it anyway.