### PR TITLE
Fixes to allow usage with Laravel 5

### DIFF
--- a/src/Baum/BaumServiceProvider.php
+++ b/src/Baum/BaumServiceProvider.php
@@ -24,15 +24,6 @@ class BaumServiceProvider extends ServiceProvider {
   protected $defer = false;
 
   /**
-   * Bootstrap the application events.
-   *
-   * @return void
-   */
-  public function boot() {
-    $this->package('baum/baum');
-  }
-
-  /**
    * Register the service provider.
    *
    * @return void

--- a/src/Baum/Console/InstallCommand.php
+++ b/src/Baum/Console/InstallCommand.php
@@ -109,7 +109,7 @@ class InstallCommand extends Command {
    * @return string
    */
   protected function getMigrationsPath() {
-    return $this->laravel['path'].'/database/migrations';
+    return base_path().'/database/migrations';
   }
 
   /**
@@ -118,7 +118,7 @@ class InstallCommand extends Command {
    * @return string
    */
   protected function getModelsPath() {
-    return $this->laravel['path'].'/models';
+    return $this->laravel['path'].'/';
   }
 
 }

--- a/src/Baum/Generators/stubs/model.php
+++ b/src/Baum/Generators/stubs/model.php
@@ -1,4 +1,5 @@
-<?php
+<?php namespace App;
+
 use Baum\Node;
 
 /**


### PR DESCRIPTION
In Baum Service Provider there is no need to bootstrap application events - removed.

In the Console Install command it references the old directory structure in L4.0 to L4.2 so i've updated the paths.

In the generator stubs it doesn't reference `namespace App;`