### PR TITLE
Separate commands for migration and model creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ The generator will install a migration and a model file into your application
 configured to work with the Nested Set behaviour provided by Baum. You SHOULD
 take a look at those files, as each of them describes how they can be customized.
 
+Also, if you like to separately create the migration and model files, you can do it like this:
+
+    php artisan baum:migration MODEL
+    php artisan baum:model MODEL
+
 Next, you would probably run `artisan migrate` to apply the migration.
 
 ### Model configuration

--- a/src/Baum/Console/MigrationCommand.php
+++ b/src/Baum/Console/MigrationCommand.php
@@ -6,14 +6,14 @@ use Baum\Generators\ModelGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 
-class InstallCommand extends Command {
+class MigrationCommand extends Command {
 
   /**
    * The console command name.
    *
    * @var string
    */
-  protected $name = 'baum:install';
+  protected $name = 'baum:migration';
 
   /**
    * The console command description.
@@ -23,12 +23,21 @@ class InstallCommand extends Command {
   protected $description = 'Scaffolds a new migration and model suitable for Baum.';
 
   /**
+   * Migration generator instance
+   *
+   * @var \Baum\Generators\MigrationGenerator
+   */
+  protected $migrator;
+
+  /**
    * Create a new command instance
    *
    * @return void
    */
-  public function __construct() {
+  public function __construct(MigrationGenerator $migrator) {
     parent::__construct();
+
+    $this->migrator = $migrator;
   }
 
   /**
@@ -44,8 +53,9 @@ class InstallCommand extends Command {
   public function fire() {
     $name = $this->input->getArgument('name');
 
-    $this->call('baum:migration', ['name' => $name]);
-    $this->call('baum:model', ['name' => $name]);
+    $output = pathinfo($this->migrator->create($name, $this->getMigrationsPath()), PATHINFO_FILENAME);
+
+    $this->line("      <fg=green;options=bold>create</fg=green;options=bold>  $output");
   }
 
   /**
@@ -57,6 +67,15 @@ class InstallCommand extends Command {
     return array(
       array('name', InputArgument::REQUIRED, 'Name to use for the scaffolding of the migration and model.')
     );
+  }
+
+  /**
+   * Get the path to the migrations directory.
+   *
+   * @return string
+   */
+  protected function getMigrationsPath() {
+    return $this->laravel['path.database'].'/migrations';
   }
 
 }

--- a/src/Baum/Console/ModelCommand.php
+++ b/src/Baum/Console/ModelCommand.php
@@ -6,29 +6,39 @@ use Baum\Generators\ModelGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 
-class InstallCommand extends Command {
+class ModelCommand extends Command {
 
   /**
    * The console command name.
    *
    * @var string
    */
-  protected $name = 'baum:install';
+  protected $name = 'baum:model';
 
   /**
    * The console command description.
    *
    * @var string
    */
-  protected $description = 'Scaffolds a new migration and model suitable for Baum.';
+  protected $description = 'Scaffolds a new model suitable for Baum.';
+
+  /**
+   * Model generator instance
+   *
+   * @var \Baum\Generators\ModelGenerator
+   */
+  protected $modeler;
 
   /**
    * Create a new command instance
    *
+   * @param ModelGenerator $modeler
    * @return void
    */
-  public function __construct() {
+  public function __construct(ModelGenerator $modeler) {
     parent::__construct();
+
+    $this->modeler = $modeler;
   }
 
   /**
@@ -44,8 +54,9 @@ class InstallCommand extends Command {
   public function fire() {
     $name = $this->input->getArgument('name');
 
-    $this->call('baum:migration', ['name' => $name]);
-    $this->call('baum:model', ['name' => $name]);
+    $output = pathinfo($this->modeler->create($name, $this->getModelsPath()), PATHINFO_FILENAME);
+
+    $this->line("      <fg=green;options=bold>create</fg=green;options=bold>  $output");
   }
 
   /**
@@ -57,6 +68,15 @@ class InstallCommand extends Command {
     return array(
       array('name', InputArgument::REQUIRED, 'Name to use for the scaffolding of the migration and model.')
     );
+  }
+
+  /**
+   * Get the path to the models directory.
+   *
+   * @return string
+   */
+  protected function getModelsPath() {
+    return $this->laravel['path.base'];
   }
 
 }

--- a/src/Baum/Providers/BaumServiceProvider.php
+++ b/src/Baum/Providers/BaumServiceProvider.php
@@ -1,6 +1,8 @@
 <?php
 namespace Baum\Providers;
 
+use Baum\Console\MigrationCommand;
+use Baum\Console\ModelCommand;
 use Baum\Generators\MigrationGenerator;
 use Baum\Generators\ModelGenerator;
 use Baum\Console\BaumCommand;
@@ -14,7 +16,7 @@ class BaumServiceProvider extends ServiceProvider {
    *
    * @var string
    */
-  const VERSION = '1.1.1';
+  const VERSION = '1.1.2';
 
   /**
    * Register the service provider.
@@ -33,10 +35,12 @@ class BaumServiceProvider extends ServiceProvider {
   public function registerCommands() {
     $this->registerBaumCommand();
     $this->registerInstallCommand();
+    $this->registerMigrationCommand();
+    $this->registerModelCommand();
 
     // Resolve the commands with Artisan by attaching the event listener to Artisan's
     // startup. This allows us to use the commands from our terminal.
-    $this->commands('command.baum', 'command.baum.install');
+    $this->commands('command.baum', 'command.baum.install', 'command.baum.migration', 'command.baum.model');
   }
 
   /**
@@ -57,10 +61,33 @@ class BaumServiceProvider extends ServiceProvider {
    */
   protected function registerInstallCommand() {
     $this->app->singleton('command.baum.install', function($app) {
+      return new InstallCommand();
+    });
+  }
+
+  /**
+   * Register the 'baum:install' command.
+   *
+   * @return void
+   */
+  protected function registerMigrationCommand() {
+    $this->app->singleton('command.baum.migration', function($app) {
       $migrator = new MigrationGenerator($app['files']);
+
+      return new MigrationCommand($migrator);
+    });
+  }
+
+  /**
+   * Register the 'baum:install' command.
+   *
+   * @return void
+   */
+  protected function registerModelCommand() {
+    $this->app->singleton('command.baum.model', function($app) {
       $modeler  = new ModelGenerator($app['files']);
 
-      return new InstallCommand($migrator, $modeler);
+      return new ModelCommand($modeler);
     });
   }
 
@@ -70,7 +97,7 @@ class BaumServiceProvider extends ServiceProvider {
    * @return array
    */
   public function provides() {
-    return array('command.baum', 'command.baum.install');
+    return array('command.baum', 'command.baum.install', 'command.baum.migration', 'command.baum.model');
   }
 
 }


### PR DESCRIPTION
I separated `baum:install` command into `baum:migration` and `baum:model` with the same command syntax. `baum:install` is still available and still does the exact same thing.

I also updated the version to _1.1.2_ but it's your call to keep that or roll it back to _1.1.1_.
