### PR TITLE
Update Node.php to Prevent Key Name Integrity errors of mysql

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -468,7 +468,7 @@ abstract class Node extends Model {
    * @return \Illuminate\Database\Query\Builder
    */
   public function scopeWithoutNode($query, $node) {
-    return $query->where($node->getKeyName(), '!=', $node->getKey());
+    return $query->where($node->getQualifiedKeyName(), '!=', $node->getKey());
   }
 
   /**

--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -568,8 +568,8 @@ abstract class Node extends Model {
    */
   public function ancestorsAndSelf() {
     return $this->newNestedSetQuery()
-                ->where($this->getLeftColumnName(), '<=', $this->getLeft())
-                ->where($this->getRightColumnName(), '>=', $this->getRight());
+                ->where($this->getQualifiedLeftColumnName(), '<=', $this->getLeft())
+                ->where($this->getQualifiedRightColumnName(), '>=', $this->getRight());
   }
 
   /**
@@ -723,8 +723,8 @@ abstract class Node extends Model {
    */
   public function descendantsAndSelf() {
     return $this->newNestedSetQuery()
-                ->where($this->getLeftColumnName(), '>=', $this->getLeft())
-                ->where($this->getLeftColumnName(), '<', $this->getRight());
+                ->where($this->getQualifiedLeftColumnName(), '>=', $this->getLeft())
+                ->where($this->getQualifiedLeftColumnName(), '<', $this->getRight());
   }
 
   /**


### PR DESCRIPTION
Use Qualified Key Name to enable Joins to the Node and prevent key name (usually ID) field Integrity Errors of mysql.
