### PR TITLE
Descendants nested list

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -1215,6 +1215,25 @@ abstract class Node extends Model {
   }
 
   /**
+   * Return an key-value array indicating the node's depth with $seperator
+   *
+   * @return Array
+   */
+  public function getDescendantsNestedList($column, $key = null, $seperator = ' ') {
+    $nodes = $this->getDescendants()->toArray();
+
+    $depthColumn = $this->getDepthColumnName();
+
+    $rootDepth = $this->{$depthColumn} + 1;
+
+    return array_combine(array_map(function($node) use($key) {
+      return $node[$key];
+    }, $nodes), array_map(function($node) use($seperator, $depthColumn, $column, $rootDepth) {
+      return str_repeat($seperator, $node[$depthColumn] - $rootDepth) . $node[$column];
+    }, $nodes));
+  }
+
+  /**
    * Maps the provided tree structure into the database using the current node
    * as the parent. The provided tree structure will be inserted/updated as the
    * descendancy subtree of the current node instance.

--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -1207,16 +1207,15 @@ abstract class Node extends Model {
 
     $nodes = $instance->newNestedSetQuery()->get()->toArray();
 
-    return array_combine(array_map(function($node) use($key) {
-      return $node[$key];
-    }, $nodes), array_map(function($node) use($seperator, $depthColumn, $column) {
-      return str_repeat($seperator, $node[$depthColumn]) . $node[$column];
-    }, $nodes));
+    return $instance->buildNestedList($nodes, $depthColumn, $column, $key, $seperator);
   }
 
   /**
-   * Return an key-value array indicating the node's depth with $seperator
+   * Return an key-value array with all nested children indicating the node's depth with $seperator
    *
+   * @param $column
+   * @param null $key
+   * @param string $seperator
    * @return Array
    */
   public function getDescendantsNestedList($column, $key = null, $seperator = ' ') {
@@ -1226,9 +1225,42 @@ abstract class Node extends Model {
 
     $rootDepth = $this->{$depthColumn} + 1;
 
-    return array_combine(array_map(function($node) use($key) {
+    return $this->buildNestedList($nodes, $depthColumn, $column, $key, $seperator, $rootDepth);
+  }
+
+  /**
+   * Return an key-value array with all nested children and self indicating the node's depth with $seperator
+   *
+   * @param $column
+   * @param null $key
+   * @param string $seperator
+   * @return Array
+   */
+  public function getDescendantsAndSelfNestedList($column, $key = null, $seperator = ' ') {
+    $nodes = $this->getDescendantsAndSelf()->toArray();
+
+    $depthColumn = $this->getDepthColumnName();
+
+    $rootDepth = $this->{$depthColumn};
+
+    return $this->buildNestedList($nodes, $depthColumn, $column, $key, $seperator, $rootDepth);
+  }
+
+  /**
+   * Build key-value array
+   *
+   * @param array $nodes
+   * @param $depthColumn
+   * @param $column
+   * @param null $key
+   * @param string $seperator
+   * @param int $rootDepth
+   * @return Array
+   */
+  private function buildNestedList(array $nodes, $depthColumn, $column, $key = null, $seperator = ' ', $rootDepth = 0) {
+    return array_combine(array_map(function ($node) use ($key) {
       return $node[$key];
-    }, $nodes), array_map(function($node) use($seperator, $depthColumn, $column, $rootDepth) {
+    }, $nodes), array_map(function ($node) use ($seperator, $depthColumn, $column, $rootDepth) {
       return str_repeat($seperator, $node[$depthColumn] - $rootDepth) . $node[$column];
     }, $nodes));
   }

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -702,4 +702,21 @@ class CategoryHierarchyTest extends CategoryTestCase {
     $this->assertArraysAreEqual($expected, $nestedList);
   }
 
+  public function testGetDescendantsNestedList() {
+    $parent = $this->categories('Root 1');
+
+    $seperator = ' ';
+
+    $nestedList = $parent->getDescendantsNestedList('name', 'id', $seperator);
+
+    $expected = array(
+      2 => str_repeat($seperator, 0). 'Child 1',
+      3 => str_repeat($seperator, 0). 'Child 2',
+      4 => str_repeat($seperator, 1). 'Child 2.1',
+      5 => str_repeat($seperator, 0). 'Child 3',
+    );
+
+    $this->assertArraysAreEqual($expected, $nestedList);
+  }
+
 }

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -703,20 +703,59 @@ class CategoryHierarchyTest extends CategoryTestCase {
   }
 
   public function testGetDescendantsNestedList() {
-    $parent = $this->categories('Root 1');
-
     $seperator = ' ';
 
-    $nestedList = $parent->getDescendantsNestedList('name', 'id', $seperator);
+    $root = $this->categories('Root 1');
+
+    $nestedList = $root->getDescendantsNestedList('name', 'id', $seperator);
 
     $expected = array(
-      2 => str_repeat($seperator, 0). 'Child 1',
-      3 => str_repeat($seperator, 0). 'Child 2',
-      4 => str_repeat($seperator, 1). 'Child 2.1',
-      5 => str_repeat($seperator, 0). 'Child 3',
+      2 => str_repeat($seperator, 0) . 'Child 1',
+      3 => str_repeat($seperator, 0) . 'Child 2',
+      4 => str_repeat($seperator, 1) . 'Child 2.1',
+      5 => str_repeat($seperator, 0) . 'Child 3',
+    );
+
+    $this->assertArraysAreEqual($expected, $nestedList);
+
+
+    $child = $this->categories('Child 2');
+
+    $nestedList = $child->getDescendantsNestedList('name', 'id', $seperator);
+
+    $expected = array(
+      4 => str_repeat($seperator, 0) . 'Child 2.1',
     );
 
     $this->assertArraysAreEqual($expected, $nestedList);
   }
 
+  public function testGetDescendantsAndSelfNestedList() {
+    $seperator = ' ';
+
+    $root = $this->categories('Root 1');
+
+    $nestedList = $root->getDescendantsAndSelfNestedList('name', 'id', $seperator);
+
+    $expected = array(
+      1 => str_repeat($seperator, 0) . 'Root 1',
+      2 => str_repeat($seperator, 1) . 'Child 1',
+      3 => str_repeat($seperator, 1) . 'Child 2',
+      4 => str_repeat($seperator, 2) . 'Child 2.1',
+      5 => str_repeat($seperator, 1) . 'Child 3',
+    );
+
+    $this->assertArraysAreEqual($expected, $nestedList);
+
+    $child = $this->categories('Child 2');
+
+    $nestedList = $child->getDescendantsAndSelfNestedList('name', 'id', $seperator);
+
+    $expected = array(
+      3 => str_repeat($seperator, 0) . 'Child 2',
+      4 => str_repeat($seperator, 1) . 'Child 2.1',
+    );
+
+    $this->assertArraysAreEqual($expected, $nestedList);
+  }
 }


### PR DESCRIPTION
This PR adds 2 methods to generate nested list from a node instance.

The new methods are:
getDescendantsNestedList and getDescendantsAndSelfNestedList.
They receive the same parameters of the static method getNestedList.

An example use case:
```php
/* Given the tree:
root
  |_ Child 1
    |_ Child 1.1
    |_ Child 1.2
  |_ Child 2
    |_ Child 2.1
    |_ Child 2.2
*/


// $node represents root
$nestedList = $node->getDescendantsNestedList('name');
// $nestedList will contain an array like the following:
// array(
//   2 => 'Child 1',
//   3 => ' Child 1.1',
//   4 => ' Child 1.2',
//   5 => 'Child 2',
//   6 => ' Child 2.1',
//   7 => ' Child 2.2',
// );

// $node represents Child 2
$nestedList = $node->getDescendantsNestedList('name');
// $nestedList will contain an array like the following:
// array(
//   6 => 'Child 2.1',
//   7 => 'Child 2.1',
// );

// $node represents root
$nestedList = $node->getDescendantsAndSelfNestedList('name');
// $nestedList will contain an array like the following:
// array(
//   1 => 'root',
//   2 => ' Child 1',
//   3 => '  Child 1.1',
//   4 => '  Child 1.2',
//   5 => ' Child 2',
//   6 => '  Child 2.1',
//   7 => '  Child 2.2',
// );

// $node represents Child 2
$nestedList = $node->getDescendantsAndSelfNestedList('name');
// $nestedList will contain an array like the following:
// array(
//   5 => 'Child 2',
//   6 => ' Child 2.1',
//   7 => ' Child 2.1',
// );


```