### PR TITLE
Concat a table name to avoid error when join query

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -468,7 +468,7 @@ abstract class Node extends Model {
    * @return \Illuminate\Database\Query\Builder
    */
   public function scopeWithoutNode($query, $node) {
-    return $query->where($node->getKeyName(), '!=', $node->getKey());
+    return $query->where($node->getTable() . '.' . $node->getKeyName(), '!=', $node->getKey());
   }
 
   /**


### PR DESCRIPTION
If 
```php
$me = \App\MyRecommend::where(['agency_id' => auth()->id()])->first();
$recommend_list = $me->descendants()->join('users', 'users.id', '=', 'recommend.user_id', 'left')->select(DB::raw('recommend.*, users.email'))->get();
```
In currently, baum will throw an exception like this issue: https://github.com/etrepat/baum/issues/285
